### PR TITLE
jr-rm-space

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.0.0 <  3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
An extra space in the version identifiers is causing issues using puppet librarian, and likely other dependency tools.